### PR TITLE
Use include for the security repository language

### DIFF
--- a/_includes/security_protocol.md
+++ b/_includes/security_protocol.md
@@ -1,0 +1,80 @@
+# Jupyter Vulnerability Handling Process
+
+This document summarizes and proposes guidelines for handling vulnerabilities reported in Jupyter projects. 
+
+Security issues and vulnerabilities have expectations and processes that are differ from typical open source practices:
+ - Private discussions
+ - Obfuscation
+ - Short timeline
+
+This makes it quite hard to be able to understand, learn, or know what to expect from a security point of view. This document
+will give you a glimpse on what's happening on the inside, and what timeline to expect when you report a security vulnerability. 
+It will also serve as a guideline and task list for Jupyter Contributors and Developers on how to handle security relatied issues.
+
+## Scope
+
+This process applies to *all projects* governed by Jupyter, including JupyterLab, Jupyter Notebook, JupyterHub, and Jupyter Server.
+
+## Reporting Vulnerabilities
+
+If you believe you’ve found a security vulnerability in a Jupyter project, please report it to security@ipython.org. If you prefer 
+to encrypt your security reports, you can use [this PGP public key](https://jupyter.org/assets/ipython_security.asc). Project Jupyter 
+will respond within 3 days to all new reports.
+
+## Coordinated Disclosures
+
+Project Jupyter follows a [coordinated disclosure](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html#responsible-or-coordinated-disclosure)
+model where the initial report and remediation are handled privately, but the completion description is made public once a patch
+is available. Project Jupyter will disclose known vulnerabilities within 90 days by default, whether a patch is available or not.
+
+## Acknowledgement
+
+Project Jupyter will work to ensure that security researchers, developers, users, or others who identify and report vulnerabilities
+within Project Jupyter software receive acknowledgement for their contribution. 
+
+## Vulnerability Triage & Remediation Process
+
+This section describes the process used by Project Jupyter to track, remediate, and disclose reported vulnerabilities. 
+This description is both a reference for the Jupyter Community and a guideline for contributors.
+
+### Roles
+
+This process defines these roles:
+- **Reporter** The individual(s) who report the vulnerability 
+- **Coordinator** A Project Jupyter contributor who facilitates the tracking of the vulnerability through this process
+- **Developer** One or more Project Jupyter developers who work on remediating the vulnerability
+
+For the purpose of this document these roles are distinct, in practice, some of these roles may be handled by the same individual. However, the roles should be covered by a minimum of two separate individuals. For example, a Reporter may also fill the Developer role and create the remediation, in this case the Coordinator should be a separate individual.
+
+### Process
+
+The role responsible for each step is noted at the beginning.
+
+- Upon receipt of the initial report:
+  - **Coordinator**: Respond to the reported and acknowledge receipt of the report in the timeframe given in the "Reporting Vulnerabilities" section.
+  - **Coordinator**: Open an issue in the private GitHub repository used for tracking vulnerabilities across projects
+  - **Coordinator**: Review the issue for completeness and suitability (triage). If more information is needed, follow up with the Reporter.
+- If the vulnerability is not accepted:
+  - **Coordinator**: Close the issue
+  - **Coordinator**: Notify the reporter
+- If the vulnerability is accepted, within the relevant repositories:
+  - **Coordinator**: Open a draft [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories#about-github-security-advisories)
+    - Include relevant but sanitized details in the top level comment, which becomes public
+    - Sensitive details and reproductions go in the comments on the draft advisory, which are not public
+    - **Coordinator**: Add relevant people to the advisory - *note* we need an official list of GitHub handles here since teams don't work across orgs
+    - **Developer**: Attempt to replicate the reported vulnerability. Request more information from the **Reporter** if necessary.
+    - **Coordinator**/**Developer**: Request a [CVE](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories#cve-identification-numbers) from GitHub. The CVE Number will be private until the advisory is published.
+    - **Developer**: Work on the [vulnerability fix PR](https://docs.github.com/en/code-security/repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability#creating-a-temporary-private-fork)
+    - Once the fix is agreed upon, wait for the CVE number to be issued.
+    - **Coordinator**: Notify the **Reporter** of the CVE number. Anyone may mention the CVE number publicly with the affected software name (without revealing version numbers).
+    - **Developer & Coordinator**: Decide on release and announcement dates and post them the draft advisory.  These are typically at least a week apart to allow administrators to deploy fixes.
+  - **Coordinator**: Post the release and announcement dates on the Jupyter Security [Mailing List]([security@ipython.org](mailto:security@ipython.org))
+  - **Developer**: Merge the security fix PR
+  - **Developer**: Make a release to PyPI and/or npm with no announcement or change log
+  - **Coordinator**: Publish the security advisory on the announcement date.  GitHub will post the CVE to the MITRE database
+- **Coordinator**: Notify the **Reporter** of the releases
+- **Coordinator**: Close the issue in the tracking repository
+
+### Note to Developers
+
+Be aware that GitHub CI workflows won't run on security forks, so reviewers must test manually to avoid a broken CI when the patch is merged to the public repo. Also, vulnerabilities may involve multiple private security forks across different GitHub organizations. This may require additional manual steps to include those private forks.

--- a/_includes/security_protocol.md
+++ b/_includes/security_protocol.md
@@ -1,3 +1,12 @@
+<!--
+  🛑🛑THIS IS A COPY, DO NOT PROPOSE CHANGES DO THIS FILE🛑🛑
+  The text here is copied from the URL below:
+  https://github.com/jupyter/security/raw/main/docs/vulnerability-handling.md
+
+  If you wish to make updates to this text, propose those changes in the security repository.
+  You may update the text below if it is copy-pasting updates from the security repo version.
+-->
+
 # Jupyter Vulnerability Handling Process
 
 This document summarizes and proposes guidelines for handling vulnerabilities reported in Jupyter projects. 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 import nox
 from pathlib import Path
+from textwrap import dedent
 
 nox.options.reuse_existing_virtualenvs = True
 
@@ -31,4 +32,15 @@ def update_security_doc(session):
     URL_SECURITY = "https://github.com/jupyter/security/raw/main/docs/vulnerability-handling.md"
     resp = requests.get(URL_SECURITY)
     includes = Path("_includes/security_protocol.md")
-    includes.write_text(resp.text)
+    text = dedent("""\
+    <!--
+      🛑🛑THIS IS A COPY, DO NOT PROPOSE CHANGES DO THIS FILE🛑🛑
+      The text here is copied from the URL below:
+      https://github.com/jupyter/security/raw/main/docs/vulnerability-handling.md
+
+      If you wish to make updates to this text, propose those changes in the security repository.
+      You may update the text below if it is copy-pasting updates from the security repo version.
+    -->
+
+    """)
+    includes.write_text(text + resp.text)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 import nox
+from pathlib import Path
 
 nox.options.reuse_existing_virtualenvs = True
 
@@ -21,3 +22,13 @@ def build_live(session):
 def build(session):
     install_deps(session)
     session.run(*"bundle exec jekyll build".split())
+
+@nox.session(name="update-security-doc")
+def update_security_doc(session):
+    session.install("requests")
+
+    import requests
+    URL_SECURITY = "https://github.com/jupyter/security/raw/main/docs/vulnerability-handling.md"
+    resp = requests.get(URL_SECURITY)
+    includes = Path("_includes/security_protocol.md")
+    includes.write_text(resp.text)

--- a/security.md
+++ b/security.md
@@ -39,88 +39,13 @@ For discussion, please use the special Discourse [security topic](https://discou
 
 ----
 
-Below is a copy of the vulnerability handling procedure that can be found on the [security repository](https://github.com/jupyter/security).
+Below is a copy of the vulnerability handling procedure that can be found on the [security repository](https://github.com/jupyter/security/blob/main/docs/vulnerability-handling.md).
 
-# Jupyter Vulnerability Handling Process
+<!--
+  The source of truth for our security protocol is the URL above.
+  We show it here as well for more visibility and an "official" feel.
+  The security protocol markdown file is manually downloaded from the URL above and placed in `_includes/`.
+  To update it, copy/paste the markdown manually, or run `nox -s update-security-doc`
+ -->
 
-This document summarizes and proposes guidelines for handling vulnerabilities reported in Jupyter projects. 
-
-Security issues and vulnerabilities have expectations and processes that are differ from typical open source practices:
- - Private discussions
- - Obfuscation
- - Short timeline
-
-This makes it quite hard to be able to understand, learn, or know what to expect from a security point of view. This document
-will give you a glimpse on what's happening on the inside, and what timeline to expect when you report a security vulnerability. 
-It will also serve as a guideline and task list for Jupyter Contributors and Developers on how to handle security relatied issues.
-
-## Scope
-
-This process applies to *all projects* governed by Jupyter, including JupyterLab, Jupyter Notebook, JupyterHub, and Jupyter Server.
-
-## Reporting Vulnerabilities
-
-If you believe you’ve found a security vulnerability in a Jupyter project, please report it to security@ipython.org. If you prefer 
-to encrypt your security reports, you can use [this PGP public key](https://jupyter.org/assets/ipython_security.asc). Project Jupyter 
-will respond within 3 days to all new reports.
-
-## Coordinated Disclosures
-
-Project Jupyter follows a [coordinated disclosure](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html#responsible-or-coordinated-disclosure)
-model where the initial report and remediation are handled privately, but the completion description is made public once a patch
-is available. Project Jupyter will disclose known vulnerabilities within 90 days by default, whether a patch is available or not.
-
-## Acknowledgement
-
-Project Jupyter will work to ensure that security researchers, developers, users, or others who identify and report vulnerabilities
-within Project Jupyter software receive acknowledgement for their contribution. 
-
-
-## Vulnerability Triage & Remediation Process
-
-This section describes the process used by Project Jupyter to track, remediate, and disclose reported vulnerabilities. 
-This description is both a reference for the Jupyter Community and a guideline for contributors.
-
-### Roles
-
-This process defines these roles:
-- **Reporter** The individual(s) who report the vulnerability 
-- **Coordinator** A Project Jupyter contributor who facilitates the tracking of the vulnerability through this process
-- **Developer** One or more Project Jupyter developers who work on remediating the vulnerability
-
-For the purpose of this document these roles are distinct, in practice, some of these roles may be handled by the same individual. However, the roles should be covered by a minimum of two separate individuals. For example, a Reporter may also fill the Developer role and create the remediation, in this case the Coordinator should be a separate individual.
-
-### Process
-
-The role responsible for each step is noted at the beginning.
-
-- Upon receipt of the initial report:
-  - **Coordinator**: Respond to the reported and acknowledge receipt of the report in the timeframe given in the "Reporting Vulnerabilities" section.
-  - **Coordinator**: Open an issue in the private GitHub repository used for tracking vulnerabilities across projects
-  - **Coordinator**: Review the issue for completeness and suitability (triage). If more information is needed, follow up with the Reporter.
-- If the vulnerability is not accepted:
-  - **Coordinator**: Close the issue
-  - **Coordinator**: Notify the reporter
-- If the vulnerability is accepted, within the relevant repositories:
-  - **Coordinator**: Open a draft [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories#about-github-security-advisories)
-    - Include relevant but sanitized details in the top level comment, which becomes public
-    - Sensitive details and reproductions go in the comments on the draft advisory, which are not public
-    - **Coordinator**: Add relevant people to the advisory - *note* we need an official list of GitHub handles here since teams don't work across orgs
-    - **Developer**: Attempt to replicate the reported vulnerability. Request more information from the **Reporter** if necessary.
-    - **Coordinator**/**Developer**: Request a [CVE](https://docs.github.com/en/code-security/repository-security-advisories/about-github-security-advisories-for-repositories#cve-identification-numbers) from GitHub. The CVE Number will be private until the advisory is published.
-    - **Developer**: Work on the [vulnerability fix PR](https://docs.github.com/en/code-security/repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability#creating-a-temporary-private-fork)
-    - Once the fix is agreed upon, wait for the CVE number to be issued.
-    - **Coordinator**: Notify the **Reporter** of the CVE number. Anyone may mention the CVE number publicly with the affected software name (without revealing version numbers).
-    - **Developer & Coordinator**: Decide on release and announcement dates and post them the draft advisory.  These are typically at least a week apart to allow administrators to deploy fixes.
-  - **Coordinator**: Post the release and announcement dates on the Jupyter Security [Mailing List]([security@ipython.org](mailto:security@ipython.org))
-  - **Developer**: Merge the security fix PR
-  - **Developer**: Make a release to PyPI and/or npm with no announcement or change log
-  - **Coordinator**: Publish the security advisory on the announcement date.  GitHub will post the CVE to the MITRE database
-- **Coordinator**: Notify the **Reporter** of the releases
-- **Coordinator**: Close the issue in the tracking repository
-
-### Note to Developers
-
-Be aware that GitHub CI workflows won't run on security forks, so reviewers must test manually to avoid a broken CI when the patch is merged to the public repo. Also, vulnerabilities may involve multiple private security forks across different GitHub organizations. This may require additional manual steps to include those private forks.
-
-
+{% include security_protocol.md %}


### PR DESCRIPTION
Here's a quick attempt at making it clearer that the security repository is the "source of truth" for this language, to avoid confusion about where to discuss changes and to make it less-likely that these become out-of-sync. It puts the markdown in an `_include` file and imports it into the security repo, along with some comments that make it clear where the source is.